### PR TITLE
adding winding number for regulators

### DIFF
--- a/src/ditto/writers/opendss/controllers/distribution_regulator_controller.py
+++ b/src/ditto/writers/opendss/controllers/distribution_regulator_controller.py
@@ -19,6 +19,7 @@ class RegulatorControllerMapper(OpenDSSMapper):
     def map_name(self):
         self.opendss_dict["Name"] = self.get_opendss_safe_name(self.model.name)
         self.opendss_dict["Transformer"] = self.get_opendss_safe_name(self.xfmr_name)
+        self.opendss_dict["Winding"] = 2
 
     def map_delay(self):
         self.opendss_dict["TapDelay"] = self.model.delay.to("s").magnitude

--- a/src/ditto/writers/opendss/controllers/distribution_regulator_controller.py
+++ b/src/ditto/writers/opendss/controllers/distribution_regulator_controller.py
@@ -19,7 +19,9 @@ class RegulatorControllerMapper(OpenDSSMapper):
     def map_name(self):
         self.opendss_dict["Name"] = self.get_opendss_safe_name(self.model.name)
         self.opendss_dict["Transformer"] = self.get_opendss_safe_name(self.xfmr_name)
-        self.opendss_dict["Winding"] = 2
+
+    def map_tapped_winding(self):
+        self.opendss_dict["Winding"] = self.model.tapped_winding
 
     def map_delay(self):
         self.opendss_dict["TapDelay"] = self.model.delay.to("s").magnitude


### PR DESCRIPTION
An issue arises in writing OpenDSS voltage regulators where the controlled winding is not specified and OpenDSS defaults to winding=1 which is not the typical expected behavior of controlling the low side. 

This was not discovered in tests because the tests disable controlled assets. By inspection, the regulators in IEEE13 would fail to be reproduced.

I have added it this way (hard-coded) because GDM has no field that captures this information. If supported by others, I could add thie to GDM:

```
class RegulatorController(Component):

    ...

    tapped_winding: Annotated[
        Optional[int],
        Field(
            2,
            ge=0,
            description="The index of the winding on the transformer that this controller is controlling.",
        ),
    ]
```

and read it in properly:
```
def map_tapped_winding(self):
    self.opendss_dict["Winding"] = self.model.tapped_winding
```